### PR TITLE
fix: add S3 address parsing method, organize error messages 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 toolchain go1.23.7
 
 replace (
-	bytetrade.io/web3os/backups-sdk => github.com/Above-Os/backups-sdk v0.1.21
+	bytetrade.io/web3os/backups-sdk => github.com/Above-Os/backups-sdk v0.1.22
 	k8s.io/api => k8s.io/api v0.25.6
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.25.6
 	k8s.io/apimachinery => k8s.io/apimachinery v0.25.6

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohl
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/Above-Os/backups-sdk v0.1.21 h1:huqKeF3jyiUA4bQJ7ZX5OF0cjndaZuJdySPKOqAlkOE=
-github.com/Above-Os/backups-sdk v0.1.21/go.mod h1:fT7a5J8LwaA2SuWLFEMj0FdK8E57BQYFc76c7JwGTRg=
+github.com/Above-Os/backups-sdk v0.1.22 h1:f1cVYn6YKWIqvLKw+1fmKWYZnyeYNRMLhvx25D1V2WI=
+github.com/Above-Os/backups-sdk v0.1.22/go.mod h1:fT7a5J8LwaA2SuWLFEMj0FdK8E57BQYFc76c7JwGTRg=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -11,7 +11,7 @@ var (
 
 const (
 	EnvSpaceUrl          string = "OLARES_SPACE_URL"
-	DefaultSyncServerURL string = "https://cloud-api.olares.xyz"
+	DefaultSyncServerURL string = "https://cloud-api.bttcdn.com"
 
 	DefaultSnapshotSizeUnit = "byte"
 	BflUserKey              = "X-BFL-USER"

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -11,7 +11,7 @@ var (
 
 const (
 	EnvSpaceUrl          string = "OLARES_SPACE_URL"
-	DefaultSyncServerURL string = "https://cloud-api.bttcdn.com"
+	DefaultSyncServerURL string = "https://cloud-api.olares.xyz"
 
 	DefaultSnapshotSizeUnit = "byte"
 	BflUserKey              = "X-BFL-USER"

--- a/pkg/handlers/handler_snapshot.go
+++ b/pkg/handlers/handler_snapshot.go
@@ -318,6 +318,7 @@ func (o *SnapshotHandler) UpdateBackupResult(ctx context.Context, snapshot *sysv
 }
 
 func (o *SnapshotHandler) update(ctx context.Context, snapshot *sysv1.Snapshot) error {
+	// todo
 	sc, err := o.factory.Sysv1Client()
 	if err != nil {
 		return err

--- a/pkg/handlers/helper.go
+++ b/pkg/handlers/helper.go
@@ -512,7 +512,7 @@ func ParseRestoreBackupUrlDetail(owner, u string) (storage *RestoreBackupUrlDeta
 }
 
 func IsBackupLocationSpace(u string) bool {
-	return strings.Contains(u, "did:key:")
+	return strings.Contains(u, constant.LocationTypeSpaceTag)
 }
 
 func ParseBackupUrl(owner, s string) (*BackupUrlType, error) {

--- a/pkg/handlers/model.go
+++ b/pkg/handlers/model.go
@@ -99,14 +99,19 @@ func (u *BackupUrlType) GetStorage() (*RestoreBackupUrlDetail, error) {
 		cloudName = u.getCloudName()
 	}
 
-	return &RestoreBackupUrlDetail{
+	var detail = &RestoreBackupUrlDetail{
 		CloudName:      cloudName,
 		RegionId:       region,
 		Bucket:         bucket,
 		Prefix:         prefix,
 		TerminusSuffix: suffix,
-		FilesystemPath: u.Endpoint,
-	}, nil
+	}
+
+	if u.Location == constant.BackupLocationFileSystem.String() {
+		detail.FilesystemPath = u.Endpoint
+	}
+
+	return detail, nil
 }
 
 func (u *BackupUrlType) getBucketAndPrefix() (bucket string, prefix string, suffix string, err error) {

--- a/pkg/modules/backup/v1/backup_schedule.go
+++ b/pkg/modules/backup/v1/backup_schedule.go
@@ -92,10 +92,11 @@ func (o *BackupPlan) validate(ctx context.Context) error {
 
 func (o *BackupPlan) mergeConfig(clusterId string) *sysv1.BackupSpec {
 	var createAt = pointer.Time()
+	var name = strings.TrimSpace(o.c.Name)
 	var backupType = make(map[string]string)
 	backupType["file"] = o.buildBackupType() // ! trim path prefix, like '/Files'
 	bc := &sysv1.BackupSpec{
-		Name:       o.c.Name,
+		Name:       name,
 		Owner:      o.owner,
 		BackupType: backupType,
 		Notified:   false,

--- a/pkg/modules/backup/v1/handler.go
+++ b/pkg/modules/backup/v1/handler.go
@@ -662,7 +662,7 @@ func (h *Handler) addRestore(req *restful.Request, resp *restful.Response) {
 		Owner:            owner,
 		Type:             restoreTypeName,
 		Path:             b.Path,
-		SubPath:          b.SubPath,
+		SubPath:          strings.TrimSpace(b.SubPath),
 		SubPathTimestamp: time.Now().Unix(),
 		BackupId:         backupId,
 		BackupName:       backupName,

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -123,6 +123,19 @@ func ListContains[T comparable](items []T, v T) bool {
 	return false
 }
 
+func ListMatchContains(items []string, v string) bool {
+	if items == nil {
+		return false
+	}
+
+	for _, item := range items {
+		if strings.Contains(v, item) {
+			return true
+		}
+	}
+	return false
+}
+
 func BytesToMD5Hash(in []byte) string {
 	hash := md5.Sum(in)
 	return hex.EncodeToString(hash[:])

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -299,8 +299,8 @@ func (w *WorkerPool) CancelBackup(owner, backupId string) {
 	if activeTask != nil {
 		backupTask := activeTask.(*ExecuteTask)
 		if backupTask.backupId == backupId {
-			backupTask.BaseTask.cancel()
 			w.sendBackupCanceledEvent(backupTask.owner, backupTask.backupId, backupTask.snapshotId)
+			backupTask.BaseTask.cancel()
 		}
 	}
 }
@@ -329,8 +329,8 @@ func (w *WorkerPool) CancelSnapshot(owner, snapshotId string) {
 	if activeTask != nil {
 		backupTask := activeTask.(*ExecuteTask)
 		if backupTask.snapshotId == snapshotId {
-			backupTask.BaseTask.cancel()
 			w.sendBackupCanceledEvent(backupTask.owner, backupTask.backupId, backupTask.snapshotId)
+			backupTask.BaseTask.cancel()
 		}
 	}
 }
@@ -360,14 +360,14 @@ func (w *WorkerPool) CancelRestore(owner, restoreId string) {
 	if activeTask != nil {
 		restoreTask := activeTask.(*ExecuteTask)
 		if restoreTask.restoreId == restoreId {
-			restoreTask.BaseTask.cancel()
 			w.sendRestoreCanceledEvent(restoreTask.owner, restoreTask.restoreId)
+			restoreTask.BaseTask.cancel()
 		}
 	}
 }
 
 func (w *WorkerPool) sendBackupCanceledEvent(owner string, backupId string, snapshotId string) {
-	w.handlers.GetNotification().Send(context.Background(), constant.EventBackup, owner, "backup canceled", map[string]interface{}{
+	w.handlers.GetNotification().Send(w.ctx, constant.EventBackup, owner, "backup canceled", map[string]interface{}{
 		"id":       snapshotId,
 		"backupId": backupId,
 		"endat":    time.Now().Unix(),
@@ -377,7 +377,7 @@ func (w *WorkerPool) sendBackupCanceledEvent(owner string, backupId string, snap
 }
 
 func (w *WorkerPool) sendRestoreCanceledEvent(owner string, restoreId string) {
-	w.handlers.GetNotification().Send(context.Background(), constant.EventRestore, owner, "restore canceled", map[string]interface{}{
+	w.handlers.GetNotification().Send(w.ctx, constant.EventRestore, owner, "restore canceled", map[string]interface{}{
 		"id":      restoreId,
 		"endat":   time.Now().Unix(),
 		"status":  constant.Canceled.String(),


### PR DESCRIPTION
Add parsing for the following three types of S3 addresses:

```
https://<bucket>.<region>.amazonaws.com/<prefixs>
https://<bucket>.s3.<region>.amazonaws.com/<prefixs>
https://s3.<region>.amazonaws.com/<bucket>/<prefixs>
```